### PR TITLE
test: make coll/allred.c compile faster

### DIFF
--- a/test/mpi/coll/allred.c
+++ b/test/mpi/coll/allred.c
@@ -19,11 +19,6 @@
 
 #include "mtest_dtp.h"
 
-int errs = 0;
-int rank, size;
-mtest_mem_type_e memtype;
-int count;
-
 struct int_test {
     int a;
     int b;
@@ -45,7 +40,84 @@ struct double_test {
     int b;
 };
 
-const char *mpi_op2str(MPI_Op op)
+enum type_category {
+    CATEGORY_INT,
+    CATEGORY_FLOAT,
+    CATEGORY_COMPLEX,
+    CATEGORY_PAIR,
+};
+
+/* global variables */
+
+static int errs = 0;
+static int rank, size;
+static mtest_mem_type_e memtype;
+static int count;
+
+static MPI_Datatype int_types[] = {
+    MPI_INT,
+    MPI_LONG,
+    MPI_SHORT,
+    MPI_UNSIGNED_SHORT,
+    MPI_UNSIGNED,
+    MPI_UNSIGNED_LONG,
+    MPI_UNSIGNED_CHAR,
+#if MTEST_HAVE_MIN_MPI_VERSION(2,2)
+    MPI_INT8_T,
+    MPI_INT16_T,
+    MPI_INT32_T,
+    MPI_INT64_T,
+    MPI_UINT8_T,
+    MPI_UINT16_T,
+    MPI_UINT32_T,
+    MPI_UINT64_T,
+    MPI_AINT,
+    MPI_OFFSET,
+#endif
+#if MTEST_HAVE_MIN_MPI_VERSION(3,0)
+    MPI_COUNT,
+#endif
+};
+
+static MPI_Datatype float_types[] = {
+    MPI_FLOAT,
+    MPI_DOUBLE,
+};
+
+static MPI_Datatype byte_types[] = {
+    MPI_BYTE,
+};
+
+#if MTEST_HAVE_MIN_MPI_VERSION(2,2)
+static MPI_Datatype complex_types[] = {
+    MPI_C_FLOAT_COMPLEX,
+    MPI_C_DOUBLE_COMPLEX,
+#ifdef HAVE_LONG_DOUBLE__COMPLEX
+    MPI_C_LONG_DOUBLE_COMPLEX,
+#endif
+};
+#endif
+
+#if MTEST_HAVE_MIN_MPI_VERSION(2,2) && defined(HAVE__BOOL)
+static MPI_Datatype logical_types[] = {
+    MPI_C_BOOL,
+};
+#endif
+
+static MPI_Datatype pair_types[] = {
+    MPI_2INT,
+    MPI_LONG_INT,
+    MPI_SHORT_INT,
+    MPI_FLOAT_INT,
+    MPI_DOUBLE_INT
+};
+
+#define MAX_TYPE_SIZE 16
+static void *in, *out, *sol;
+static void *in_d, *out_d;
+
+/* internal routines */
+static const char *mpi_op2str(MPI_Op op)
 {
     return ((op == MPI_SUM) ? "MPI_SUM" :
             (op == MPI_PROD) ? "MPI_PROD" :
@@ -61,57 +133,284 @@ const char *mpi_op2str(MPI_Op op)
 }
 
 /* calloc to avoid spurious valgrind warnings when "type" has padding bytes */
-#define DECL_MALLOC_IN_OUT_SOL(type)            \
-    type *in, *out, *sol; /*allocated on host*/ \
-    void *in_d, *out_d; /*allocated on device*/ \
-    MTestCalloc(count * sizeof(type), memtype, ((void **)&in), &in_d, rank);  \
-    MTestCalloc(count * sizeof(type), memtype, ((void **)&out), &out_d, rank);\
-    sol = (type *) calloc(count, sizeof(type));
+static void malloc_in_out_sol(int memtype, int rank)
+{
+    MTestCalloc(count * MAX_TYPE_SIZE, memtype, &in, &in_d, rank);
+    MTestCalloc(count * MAX_TYPE_SIZE, memtype, &out, &out_d, rank);
+    sol = calloc(count, MAX_TYPE_SIZE);
+}
 
-#define SET_INDEX_CONST(arr, val)               \
-    {                                           \
-        int i;                                  \
-        for (i = 0; i < count; i++)             \
-            arr[i] = val;                       \
+static void free_in_out_sol(int memtype)
+{
+    MTestFree(memtype, in, in_d);
+    MTestFree(memtype, out, out_d);
+    free(sol);
+}
+
+static int get_mpi_type_size(MPI_Datatype mpi_type)
+{
+    MPI_Aint lb, extent;
+    MPI_Type_get_extent(mpi_type, &lb, &extent);
+    return extent;
+}
+
+static void set_int_value(void *p, int type_size, int val)
+{
+    switch (type_size) {
+        case 1:
+            *(int8_t *) p = (int8_t) val;
+            break;
+        case 2:
+            *(int16_t *) p = (int16_t) val;
+            break;
+        case 4:
+            *(int32_t *) p = (int32_t) val;
+            break;
+        case 8:
+            *(int64_t *) p = (int64_t) val;
+            break;
+        default:
+            assert(0);
     }
+}
 
-#define SET_INDEX_SUM(arr, val)                 \
-    {                                           \
-        int i;                                  \
-        for (i = 0; i < count; i++)             \
-            arr[i] = i + val;                   \
+static void set_float_value(void *p, int type_size, int val)
+{
+    if (type_size == 4) {
+        *(float *) p = (float) val;
+    } else if (type_size == 8) {
+        *(double *) p = (double) val;
+    } else {
+        assert(0);
     }
+}
 
-#define SET_INDEX_FACTOR(arr, val)              \
-    {                                           \
-        int i;                                  \
-        for (i = 0; i < count; i++)             \
-            arr[i] = i * (val);                 \
+static void set_complex_value(void *p, int type_size, int val)
+{
+    if (type_size == 8) {
+        *(float _Complex *) p = (float _Complex) val;
+    } else if (type_size == 16) {
+        *(double _Complex *) p = (double _Complex) val;
+#ifdef HAVE_LONG_DOUBLE__COMPLEX
+    } else if (type_size == 32) {
+        *(long double _Complex *) p = (long double _Complex) val;
+#endif
+    } else {
+        assert(0);
     }
+}
 
-#define SET_INDEX_POWER(arr, val)               \
-    {                                           \
-        int i, j;                               \
-        for (i = 0; i < count; i++) {           \
-            (arr)[i] = 1;                       \
-            for (j = 0; j < (val); j++)         \
-                arr[i] *= i;                    \
-        }                                       \
+static void set_category_value(int category, void *p, int type_size, int val)
+{
+    if (category == CATEGORY_INT) {
+        set_int_value(p, type_size, val);
+    } else if (category == CATEGORY_FLOAT) {
+        set_float_value(p, type_size, val);
+    } else if (category == CATEGORY_COMPLEX) {
+        set_complex_value(p, type_size, val);
+    } else {
+        assert(0);
     }
+}
 
-#define ERROR_CHECK_AND_FREE(lerrcnt, mpi_type, mpi_op)                 \
-    do {                                                                \
-        char name[MPI_MAX_OBJECT_NAME] = {0};                           \
-        int len = 0;                                                    \
-        if (lerrcnt) {                                                  \
-            MPI_Type_get_name(mpi_type, name, &len);                    \
-            fprintf(stderr, "(%d) Error for type %s and op %s\n",       \
-                    rank, name, mpi_op2str(mpi_op));                    \
-        }                                                               \
-        MTestFree(memtype, in, in_d);                                   \
-        MTestFree(memtype, out, out_d);                                 \
-        free(sol);                                                      \
-    } while (0)
+static void set_index_const(MPI_Datatype mpi_type, int category, void *arr, int val, int count)
+{
+    int type_size = get_mpi_type_size(mpi_type);
+    char *p = arr;
+    for (int i = 0; i < count; i++) {
+        set_category_value(category, p, type_size, val);
+        p += type_size;
+    }
+}
+
+static void set_index_sum(MPI_Datatype mpi_type, int category, void *arr, int val, int count)
+{
+    int type_size = get_mpi_type_size(mpi_type);
+    char *p = arr;
+    for (int i = 0; i < count; i++) {
+        set_category_value(category, p, type_size, i + val);
+        p += type_size;
+    }
+}
+
+static void set_index_factor(MPI_Datatype mpi_type, int category, void *arr, int val, int count)
+{
+    int type_size = get_mpi_type_size(mpi_type);
+    char *p = arr;
+    for (int i = 0; i < count; i++) {
+        set_category_value(category, p, type_size, i * val);
+        p += type_size;
+    }
+}
+
+static int get_pow(int base, int n)
+{
+    int ans = 1;
+    for (int i = 0; i < n; i++) {
+        ans *= base;
+    }
+    return ans;
+}
+
+static void set_index_power(MPI_Datatype mpi_type, int category, void *arr, int val, int count)
+{
+    int type_size = get_mpi_type_size(mpi_type);
+    char *p = arr;
+    for (int i = 0; i < count; i++) {
+        set_category_value(category, p, type_size, get_pow(i, val));
+        p += type_size;
+    }
+}
+
+#define SET_PAIR_CASE(type, mpi_type) \
+    case mpi_type: \
+        { \
+            struct type ## _test *pp = p; \
+            pp->a = val_a; \
+            pp->b = val_b; \
+        }; \
+        break
+
+static void set_pair_val(MPI_Datatype mpi_type, void *p, int val_a, int val_b)
+{
+    switch (mpi_type) {
+            SET_PAIR_CASE(int, MPI_2INT);
+            SET_PAIR_CASE(long, MPI_LONG_INT);
+            SET_PAIR_CASE(short, MPI_SHORT_INT);
+            SET_PAIR_CASE(float, MPI_FLOAT_INT);
+            SET_PAIR_CASE(double, MPI_DOUBLE_INT);
+        default:
+            assert(0);
+    }
+}
+
+static void set_index_pair_const(MPI_Datatype mpi_type, void *arr, int val_a, int val_b, int count)
+{
+    int type_size = get_mpi_type_size(mpi_type);
+    char *p = arr;
+    for (int i = 0; i < count; i++) {
+        set_pair_val(mpi_type, p, val_a, val_b);
+        p += type_size;
+    }
+}
+
+static void set_index_pair_sum(MPI_Datatype mpi_type, void *arr, int val_a, int val_b, int count)
+{
+    int type_size = get_mpi_type_size(mpi_type);
+    char *p = arr;
+    for (int i = 0; i < count; i++) {
+        set_pair_val(mpi_type, p, i + val_a, val_b);
+        p += type_size;
+    }
+}
+
+static int cmp_float(void *p, void *q, int type_size)
+{
+    if (type_size == 4) {
+        if (*(float *) p != *(float *) q) {
+            return 1;
+        }
+    } else if (type_size == 8) {
+        if (*(double *) p != *(double *) q) {
+            return 1;
+        }
+    } else {
+        assert(0);
+    }
+    return 0;
+}
+
+static int cmp_complex(void *p, void *q, int type_size)
+{
+    if (type_size == 8) {
+        if (*(float _Complex *) p != *(float _Complex *) q) {
+            return 1;
+        }
+    } else if (type_size == 16) {
+        if (*(double _Complex *) p != *(double _Complex *) q) {
+            return 1;
+        }
+#ifdef HAVE_LONG_DOUBLE__COMPLEX
+    } else if (type_size == 32) {
+        if (*(long double _Complex *) p != *(long double _Complex *) q) {
+            return 1;
+        }
+#endif
+    } else {
+        assert(0);
+    }
+    return 0;
+}
+
+static int cmp_int(void *p, void *q, int type_size)
+{
+    if (memcmp(p, q, type_size) == 0) {
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
+#define CMP_PAIR_CASE(type, mpi_type) \
+    case mpi_type: \
+        do { \
+            struct type ## _test *pp, *qq; \
+            pp = p; \
+            qq = q; \
+            if (pp->a == qq->a && pp->b == qq->b) { \
+                return 0; \
+            } else { \
+                return 1; \
+            } \
+        } while (0)
+
+static int cmp_pair(void *p, void *q, MPI_Datatype mpi_type)
+{
+    switch (mpi_type) {
+            CMP_PAIR_CASE(int, MPI_2INT);
+            CMP_PAIR_CASE(long, MPI_LONG_INT);
+            CMP_PAIR_CASE(short, MPI_SHORT_INT);
+            CMP_PAIR_CASE(float, MPI_FLOAT_INT);
+            CMP_PAIR_CASE(double, MPI_DOUBLE_INT);
+        default:
+            assert(0);
+    }
+    return 1;
+}
+
+static int cmp_arr_value(MPI_Datatype mpi_type, int category, void *arr1, void *arr2, int count)
+{
+    int err = 0;
+
+    int type_size = get_mpi_type_size(mpi_type);
+    char *p = arr1;
+    char *q = arr2;
+    for (int i = 0; i < count; i++) {
+        if (category == CATEGORY_INT) {
+            err += cmp_int(p, q, type_size);
+        } else if (category == CATEGORY_FLOAT) {
+            err += cmp_float(p, q, type_size);
+        } else if (category == CATEGORY_COMPLEX) {
+            err += cmp_complex(p, q, type_size);
+        } else if (category == CATEGORY_PAIR) {
+            err += cmp_pair(p, q, mpi_type);
+        } else {
+            assert(0);
+        }
+        p += type_size;
+        q += type_size;
+    }
+    return err;
+}
+
+static void report_error(int rank, MPI_Datatype mpi_type, MPI_Op op)
+{
+    char name[MPI_MAX_OBJECT_NAME] = { 0 };
+    int len = 0;
+
+    MPI_Type_get_name(mpi_type, name, &len);
+    printf("(%d) Error for type %s and op %s\n", rank, name, mpi_op2str(op));
+}
 
 /* The logic on the error check on MPI_Allreduce assumes that all
    MPI_Allreduce routines return a failure if any do - this is sufficient
@@ -119,443 +418,162 @@ const char *mpi_op2str(MPI_Op op)
    (and motivated this addition, as some versions of the IBM MPI
    failed in just this way).
 */
-#define ALLREDUCE_AND_FREE(type, mpi_type, mpi_op, in, out, sol)        \
-    {                                                                   \
-        int i, rc, lerrcnt = 0;						\
-        MTestCopyContent(in, in_d, count * sizeof(type),  memtype);     \
-        rc = MPI_Allreduce(in_d, out_d, count, mpi_type, mpi_op, MPI_COMM_WORLD); \
-        MTestCopyContent(out_d, out, count * sizeof(type), memtype);    \
-        if (rc) { lerrcnt++; errs++; MTestPrintError(rc); }             \
-        else {                                                          \
-            for (i = 0; i < count; i++) {                               \
-                if (out[i] != sol[i]) {                                 \
-                    errs++;                                             \
-                    lerrcnt++;                                          \
-                }                                                       \
-            }                                                           \
-        }                                                               \
-        ERROR_CHECK_AND_FREE(lerrcnt, mpi_type, mpi_op);                \
+
+static int allreduce_and_check(MPI_Datatype mpi_type, int category, MPI_Op op, int memtype)
+{
+    int lerrcnt = 0;
+
+    int type_size = get_mpi_type_size(mpi_type);
+    MTestCopyContent(in, in_d, count * type_size, memtype);
+    int rc = MPI_Allreduce(in_d, out_d, count, mpi_type, op, MPI_COMM_WORLD);
+    MTestCopyContent(out_d, out, count * type_size, memtype);
+
+    if (rc) {
+        lerrcnt++;
+        MTestPrintError(rc);
+    } else {
+        lerrcnt += cmp_arr_value(mpi_type, category, out, sol, count);
     }
 
-#define STRUCT_ALLREDUCE_AND_FREE(type, mpi_type, mpi_op, in, out, sol) \
-    {                                                                   \
-        int i, rc, lerrcnt = 0;						\
-        MTestCopyContent(in, in_d, count * sizeof(type),  memtype);     \
-        rc = MPI_Allreduce(in_d, out_d, count, mpi_type, mpi_op, MPI_COMM_WORLD); \
-        MTestCopyContent(out_d, out, count * sizeof(type), memtype);    \
-        if (rc) { lerrcnt++; errs++; MTestPrintError(rc); }             \
-        else {                                                          \
-            for (i = 0; i < count; i++) {                               \
-                if ((out[i].a != sol[i].a) || (out[i].b != sol[i].b)) { \
-                    errs++;                                             \
-                    lerrcnt++;                                          \
-                }                                                       \
-            }                                                           \
-        }                                                               \
-        ERROR_CHECK_AND_FREE(lerrcnt, mpi_type, mpi_op);                \
+    if (lerrcnt > 0) {
+        errs += lerrcnt;
+        report_error(rank, mpi_type, op);
     }
+}
 
-#define SET_INDEX_STRUCT_CONST(arr, val, el)    \
-    {                                           \
-        int i;                                  \
-        for (i = 0; i < count; i++)             \
-            arr[i].el = val;                    \
-    }
+static void sum_test_1(MPI_Datatype mpi_type, int category, int memtype)
+{
+    set_index_sum(mpi_type, category, in, 0, count);
+    set_index_factor(mpi_type, category, sol, size, count);
+    set_index_const(mpi_type, category, out, 0, count);
+    allreduce_and_check(mpi_type, category, MPI_SUM, memtype);
+}
 
-#define SET_INDEX_STRUCT_SUM(arr, val, el)      \
-    {                                           \
-        int i;                                  \
-        for (i = 0; i < count; i++)             \
-            arr[i].el = i + (val);              \
-    }
+static void prod_test_1(MPI_Datatype mpi_type, int category, int memtype)
+{
+    set_index_sum(mpi_type, category, in, 0, count);
+    set_index_power(mpi_type, category, sol, size, count);
+    set_index_const(mpi_type, category, out, 0, count);
+    allreduce_and_check(mpi_type, category, MPI_PROD, memtype);
+}
 
-#define sum_test1(type, mpi_type)                               \
-    {                                                           \
-        DECL_MALLOC_IN_OUT_SOL(type);                           \
-        SET_INDEX_SUM(in, 0);                                   \
-        SET_INDEX_FACTOR(sol, size);                            \
-        SET_INDEX_CONST(out, 0);                                \
-        ALLREDUCE_AND_FREE(type, mpi_type, MPI_SUM, in, out, sol);    \
-    }
+static void max_test_1(MPI_Datatype mpi_type, int category, int memtype)
+{
+    set_index_sum(mpi_type, category, in, rank, count);
+    set_index_sum(mpi_type, category, sol, size - 1, count);
+    set_index_const(mpi_type, category, out, 0, count);
+    allreduce_and_check(mpi_type, category, MPI_MAX, memtype);
+}
 
-#define prod_test1(type, mpi_type)                              \
-    {                                                           \
-        DECL_MALLOC_IN_OUT_SOL(type);                           \
-        SET_INDEX_SUM(in, 0);                                   \
-        SET_INDEX_POWER(sol, size);                             \
-        SET_INDEX_CONST(out, 0);                                \
-        ALLREDUCE_AND_FREE(type, mpi_type, MPI_PROD, in, out, sol);   \
-    }
+static void min_test_1(MPI_Datatype mpi_type, int category, int memtype)
+{
+    set_index_sum(mpi_type, category, in, rank, count);
+    set_index_sum(mpi_type, category, sol, 0, count);
+    set_index_const(mpi_type, category, out, 0, count);
+    allreduce_and_check(mpi_type, category, MPI_MIN, memtype);
+}
 
-#define max_test1(type, mpi_type)                               \
-    {                                                           \
-        DECL_MALLOC_IN_OUT_SOL(type);                           \
-        SET_INDEX_SUM(in, rank);                                \
-        SET_INDEX_SUM(sol, size - 1);                           \
-        SET_INDEX_CONST(out, 0);                                \
-        ALLREDUCE_AND_FREE(type, mpi_type, MPI_MAX, in, out, sol);    \
-    }
-
-#define min_test1(type, mpi_type)                               \
-    {                                                           \
-        DECL_MALLOC_IN_OUT_SOL(type);                           \
-        SET_INDEX_SUM(in, rank);                                \
-        SET_INDEX_SUM(sol, 0);                                  \
-        SET_INDEX_CONST(out, 0);                                \
-        ALLREDUCE_AND_FREE(type, mpi_type, MPI_MIN, in, out, sol);    \
-    }
-
-#define const_test(type, mpi_type, mpi_op, val1, val2, val3)    \
-    {                                                           \
-        DECL_MALLOC_IN_OUT_SOL(type);                           \
-        SET_INDEX_CONST(in, (val1));                            \
-        SET_INDEX_CONST(sol, (val2));                           \
-        SET_INDEX_CONST(out, (val3));                           \
-        ALLREDUCE_AND_FREE(type, mpi_type, mpi_op, in, out, sol);     \
-    }
-
-#define lor_test1(type, mpi_type)                                       \
-    const_test(type, mpi_type, MPI_LOR, (rank & 0x1), (size > 1), 0)
-#define lor_test2(type, mpi_type)                       \
-    const_test(type, mpi_type, MPI_LOR, 0, 0, 0)
-#define lxor_test1(type, mpi_type)                                      \
-    const_test(type, mpi_type, MPI_LXOR, (rank == 1), (size > 1), 0)
-#define lxor_test2(type, mpi_type)                      \
-    const_test(type, mpi_type, MPI_LXOR, 0, 0, 0)
-#define lxor_test3(type, mpi_type)                              \
-    const_test(type, mpi_type, MPI_LXOR, 1, (size & 0x1), 0)
-#define land_test1(type, mpi_type)                              \
-    const_test(type, mpi_type, MPI_LAND, (rank & 0x1), 0, 0)
-#define land_test2(type, mpi_type)                      \
-    const_test(type, mpi_type, MPI_LAND, 1, 1, 0)
-#define bor_test1(type, mpi_type)                                       \
-    const_test(type, mpi_type, MPI_BOR, (rank & 0x3), ((size < 3) ? size - 1 : 0x3), 0)
-#define bxor_test1(type, mpi_type)                                      \
-    const_test(type, mpi_type, MPI_BXOR, (rank == 1) * 0xf0, (size > 1) * 0xf0, 0)
-#define bxor_test2(type, mpi_type)                      \
-    const_test(type, mpi_type, MPI_BXOR, 0, 0, 0)
-#define bxor_test3(type, mpi_type)                                      \
-    const_test(type, mpi_type, MPI_BXOR, ~0, (size &0x1) ? ~0 : 0, 0)
-
-#define band_test1(type, mpi_type)                              \
-    {                                                           \
-        DECL_MALLOC_IN_OUT_SOL(type);                           \
-        if (rank == size-1) {                                   \
-            SET_INDEX_SUM(in, 0);                               \
-        }                                                       \
-        else {                                                  \
-            SET_INDEX_CONST(in, ~0);                            \
-        }                                                       \
-        SET_INDEX_SUM(sol, 0);                                  \
-        SET_INDEX_CONST(out, 0);                                \
-        ALLREDUCE_AND_FREE(type, mpi_type, MPI_BAND, in, out, sol);   \
-    }
-
-#define band_test2(type, mpi_type)                              \
-    {                                                           \
-        DECL_MALLOC_IN_OUT_SOL(type);                           \
-        if (rank == size-1) {                                   \
-            SET_INDEX_SUM(in, 0);                               \
-        }                                                       \
-        else {                                                  \
-            SET_INDEX_CONST(in, 0);                             \
-        }                                                       \
-        SET_INDEX_CONST(sol, 0);                                \
-        SET_INDEX_CONST(out, 0);                                \
-        ALLREDUCE_AND_FREE(type, mpi_type, MPI_BAND, in, out, sol);   \
-    }
-
-#define maxloc_test(type, mpi_type)                                     \
-    static void maxloc_test_ ## mpi_type() \
-    {                                                                   \
-        DECL_MALLOC_IN_OUT_SOL(type);                                   \
-        SET_INDEX_STRUCT_SUM(in, rank, a);                              \
-        SET_INDEX_STRUCT_CONST(in, rank, b);                            \
-        SET_INDEX_STRUCT_SUM(sol, size - 1, a);                         \
-        SET_INDEX_STRUCT_CONST(sol, size - 1, b);                       \
-        SET_INDEX_STRUCT_CONST(out, 0, a);                              \
-        SET_INDEX_STRUCT_CONST(out, -1, b);                             \
-        STRUCT_ALLREDUCE_AND_FREE(type, mpi_type, MPI_MAXLOC, in, out, sol);  \
-    }
-
-maxloc_test(struct int_test, MPI_2INT);
-maxloc_test(struct long_test, MPI_LONG_INT);
-maxloc_test(struct short_test, MPI_SHORT_INT);
-maxloc_test(struct float_test, MPI_FLOAT_INT);
-maxloc_test(struct double_test, MPI_DOUBLE_INT);
-
-#define minloc_test(type, mpi_type)                                     \
-    static void minloc_test_ ## mpi_type() \
-    {                                                                   \
-        DECL_MALLOC_IN_OUT_SOL(type);                                   \
-        SET_INDEX_STRUCT_SUM(in, rank, a);                              \
-        SET_INDEX_STRUCT_CONST(in, rank, b);                            \
-        SET_INDEX_STRUCT_SUM(sol, 0, a);                                \
-        SET_INDEX_STRUCT_CONST(sol, 0, b);                              \
-        SET_INDEX_STRUCT_CONST(out, 0, a);                              \
-        SET_INDEX_STRUCT_CONST(out, -1, b);                             \
-        STRUCT_ALLREDUCE_AND_FREE(type, mpi_type, MPI_MINLOC, in, out, sol);  \
-    }
-
-minloc_test(struct int_test, MPI_2INT);
-minloc_test(struct long_test, MPI_LONG_INT);
-minloc_test(struct short_test, MPI_SHORT_INT);
-minloc_test(struct float_test, MPI_FLOAT_INT);
-minloc_test(struct double_test, MPI_DOUBLE_INT);
-
-#if MTEST_HAVE_MIN_MPI_VERSION(2,2)
-#define test_types_set_mpi_2_2_integer(op,post) do {    \
-        op##_test##post(int8_t, MPI_INT8_T);            \
-        op##_test##post(int16_t, MPI_INT16_T);          \
-        op##_test##post(int32_t, MPI_INT32_T);          \
-        op##_test##post(int64_t, MPI_INT64_T);          \
-        op##_test##post(uint8_t, MPI_UINT8_T);          \
-        op##_test##post(uint16_t, MPI_UINT16_T);        \
-        op##_test##post(uint32_t, MPI_UINT32_T);        \
-        op##_test##post(uint64_t, MPI_UINT64_T);        \
-        op##_test##post(MPI_Aint, MPI_AINT);            \
-        op##_test##post(MPI_Offset, MPI_OFFSET);        \
-    } while (0)
-#else
-#define test_types_set_mpi_2_2_integer(op,post) do { } while (0)
-#endif
-
-#if MTEST_HAVE_MIN_MPI_VERSION(3,0)
-#define test_types_set_mpi_3_0_integer(op,post) do {    \
-        op##_test##post(MPI_Count, MPI_COUNT);          \
-    } while (0)
-#else
-#define test_types_set_mpi_3_0_integer(op,post) do { } while (0)
-#endif
-
-#define test_types_set1(op, post)                               \
-    {                                                           \
-        op##_test##post(int, MPI_INT);                          \
-        op##_test##post(long, MPI_LONG);                        \
-        op##_test##post(short, MPI_SHORT);                      \
-        op##_test##post(unsigned short, MPI_UNSIGNED_SHORT);    \
-        op##_test##post(unsigned, MPI_UNSIGNED);                \
-        op##_test##post(unsigned long, MPI_UNSIGNED_LONG);      \
-        op##_test##post(unsigned char, MPI_UNSIGNED_CHAR);      \
-        test_types_set_mpi_2_2_integer(op,post);                \
-        test_types_set_mpi_3_0_integer(op,post);                \
-    }
-
-#define test_types_set2(op, post)               \
-    {                                           \
-        test_types_set1(op, post);              \
-        op##_test##post(float, MPI_FLOAT);      \
-        op##_test##post(double, MPI_DOUBLE);    \
-    }
-
-#define test_types_set3(op, post)                       \
-    {                                                   \
-        op##_test##post(unsigned char, MPI_BYTE);       \
-    }
-
-/* Make sure that we test complex and double complex, even if long
-   double complex is not available */
-#if defined(USE_LONG_DOUBLE_COMPLEX)
-
-#if MTEST_HAVE_MIN_MPI_VERSION(2,2) && defined(HAVE_FLOAT__COMPLEX)     \
-    && defined(HAVE_DOUBLE__COMPLEX)                                    \
-    && defined(HAVE_LONG_DOUBLE__COMPLEX)
-#define test_types_set4(op, post)                                       \
-    do {                                                                \
-        op##_test##post(float _Complex, MPI_C_FLOAT_COMPLEX);           \
-        op##_test##post(double _Complex, MPI_C_DOUBLE_COMPLEX);         \
-        if (MPI_C_LONG_DOUBLE_COMPLEX != MPI_DATATYPE_NULL) {           \
-            op##_test##post(long double _Complex, MPI_C_LONG_DOUBLE_COMPLEX); \
-        }                                                               \
+#define const_test(mpi_op, val1, val2, val3)    \
+    do { \
+        set_index_const(mpi_type, category, in, val1, count); \
+        set_index_const(mpi_type, category, sol, val2, count); \
+        set_index_const(mpi_type, category, out, val3, count); \
+        allreduce_and_check(mpi_type, category, mpi_op, memtype); \
     } while (0)
 
-#else
-#define test_types_set4(op, post) do { } while (0)
-#endif
-#else
-
-#if MTEST_HAVE_MIN_MPI_VERSION(2,2) && defined(HAVE_FLOAT__COMPLEX)     \
-    && defined(HAVE_DOUBLE__COMPLEX)
-#define test_types_set4(op, post)                               \
-    do {                                                        \
-        op##_test##post(float _Complex, MPI_C_FLOAT_COMPLEX);   \
-        op##_test##post(double _Complex, MPI_C_DOUBLE_COMPLEX); \
-    } while (0)
-
-#else
-#define test_types_set4(op, post) do { } while (0)
-#endif
-
-#endif /* defined(USE_LONG_DOUBLE_COMPLEX) */
-
-#if MTEST_HAVE_MIN_MPI_VERSION(2,2) && defined(HAVE__BOOL)
-#define test_types_set5(op, post)               \
-    do {                                        \
-        op##_test##post(_Bool, MPI_C_BOOL);     \
-    } while (0)
-
-#else
-#define test_types_set5(op, post) do { } while (0)
-#endif
-
-static void test_types_set2_sum_1()
+static void lor_test_1(MPI_Datatype mpi_type, int category, int memtype)
 {
-    test_types_set2(sum, 1);
+    const_test(MPI_LOR, (rank & 0x1), (size > 1), 0);
 }
 
-static void test_types_set2_prod_1()
+static void lor_test_2(MPI_Datatype mpi_type, int category, int memtype)
 {
-    test_types_set2(prod, 1);
+    const_test(MPI_LOR, 0, 0, 0);
 }
 
-static void test_types_set2_max_1()
+static void lxor_test_1(MPI_Datatype mpi_type, int category, int memtype)
 {
-    test_types_set2(max, 1);
+    const_test(MPI_LXOR, (rank == 1), (size > 1), 0);
 }
 
-static void test_types_set2_min_1()
+static void lxor_test_2(MPI_Datatype mpi_type, int category, int memtype)
 {
-    test_types_set2(min, 1);
+    const_test(MPI_LXOR, 0, 0, 0);
 }
 
-static void test_types_set1_lor_1()
+static void lxor_test_3(MPI_Datatype mpi_type, int category, int memtype)
 {
-    test_types_set1(lor, 1);
+    const_test(MPI_LXOR, 1, (size & 0x1), 0);
 }
 
-static void test_types_set1_lor_2()
+static void land_test_1(MPI_Datatype mpi_type, int category, int memtype)
 {
-    test_types_set1(lor, 2);
+    const_test(MPI_LAND, (rank & 0x1), 0, 0);
 }
 
-static void test_types_set1_lxor_1()
+static void land_test_2(MPI_Datatype mpi_type, int category, int memtype)
 {
-    test_types_set1(lxor, 1);
+    const_test(MPI_LAND, 1, 1, 0);
 }
 
-static void test_types_set1_lxor_2()
+static void bor_test_1(MPI_Datatype mpi_type, int category, int memtype)
 {
-    test_types_set1(lxor, 2);
+    const_test(MPI_BOR, (rank & 0x3), ((size < 3) ? size - 1 : 0x3), 0);
 }
 
-static void test_types_set1_lxor_3()
+static void bxor_test_1(MPI_Datatype mpi_type, int category, int memtype)
 {
-    test_types_set1(lxor, 3);
+    const_test(MPI_BXOR, (rank == 1) * 0xf0, (size > 1) * 0xf0, 0);
 }
 
-static void test_types_set1_land_1()
+static void bxor_test_2(MPI_Datatype mpi_type, int category, int memtype)
 {
-    test_types_set1(land, 1);
+    const_test(MPI_BXOR, 0, 0, 0);
 }
 
-static void test_types_set1_land_2()
+static void bxor_test_3(MPI_Datatype mpi_type, int category, int memtype)
 {
-    test_types_set1(land, 2);
+    const_test(MPI_BXOR, ~0, (size & 0x1) ? ~0 : 0, 0);
 }
 
-static void test_types_set1_bor_1()
+static void band_test_1(MPI_Datatype mpi_type, int category, int memtype)
 {
-    test_types_set1(bor, 1);
+    if (rank == size - 1) {
+        set_index_sum(mpi_type, category, in, 0, count);
+    } else {
+        set_index_const(mpi_type, category, in, ~0, count);
+    }
+    set_index_sum(mpi_type, category, sol, 0, count);
+    set_index_const(mpi_type, category, out, 0, count);
+    allreduce_and_check(mpi_type, category, MPI_BAND, memtype);
 }
 
-static void test_types_set1_band_1()
+static void band_test_2(MPI_Datatype mpi_type, int category, int memtype)
 {
-    test_types_set1(band, 1);
+    if (rank == size - 1) {
+        set_index_sum(mpi_type, category, in, 0, count);
+    } else {
+        set_index_const(mpi_type, category, in, 0, count);
+    }
+    set_index_const(mpi_type, category, sol, 0, count);
+    set_index_const(mpi_type, category, out, 0, count);
+    allreduce_and_check(mpi_type, category, MPI_BAND, memtype);
 }
 
-static void test_types_set1_band_2()
+static void maxloc_test(MPI_Datatype mpi_type, int memtype)
 {
-    test_types_set1(band, 2);
+    set_index_pair_sum(mpi_type, in, rank, rank, count);
+    set_index_pair_sum(mpi_type, sol, size - 1, size - 1, count);
+    set_index_pair_const(mpi_type, out, 0, -1, count);
+    allreduce_and_check(mpi_type, CATEGORY_PAIR, MPI_MAXLOC, memtype);
 }
 
-static void test_types_set1_bxor_1()
+static void minloc_test(MPI_Datatype mpi_type, int memtype)
 {
-    test_types_set1(bxor, 1);
-}
-
-static void test_types_set1_bxor_2()
-{
-    test_types_set1(bxor, 2);
-}
-
-static void test_types_set1_bxor_3()
-{
-    test_types_set1(bxor, 3);
-}
-
-static void test_types_set3_bor_1()
-{
-    test_types_set3(bor, 1);
-}
-
-static void test_types_set3_band_1()
-{
-    test_types_set3(band, 1);
-}
-
-static void test_types_set3_band_2()
-{
-    test_types_set3(band, 2);
-}
-
-static void test_types_set3_bxor_1()
-{
-    test_types_set3(bxor, 1);
-}
-
-static void test_types_set3_bxor_2()
-{
-    test_types_set3(bxor, 2);
-}
-
-static void test_types_set3_bxor_3()
-{
-    test_types_set3(bxor, 3);
-}
-
-static void test_types_set4_sum_1()
-{
-    test_types_set4(sum, 1);
-}
-
-static void test_types_set4_prod_1()
-{
-    test_types_set4(prod, 1);
-}
-
-static void test_types_set5_lor_1()
-{
-    test_types_set5(lor, 1);
-}
-
-static void test_types_set5_lor_2()
-{
-    test_types_set5(lor, 2);
-}
-
-static void test_types_set5_lxor_1()
-{
-    test_types_set5(lxor, 1);
-}
-
-static void test_types_set5_lxor_2()
-{
-    test_types_set5(lxor, 2);
-}
-
-static void test_types_set5_lxor_3()
-{
-    test_types_set5(lxor, 3);
-}
-
-static void test_types_set5_land_1()
-{
-    test_types_set5(land, 1);
-}
-
-static void test_types_set5_land_2()
-{
-    test_types_set5(land, 2);
+    set_index_pair_sum(mpi_type, in, rank, rank, count);
+    set_index_pair_sum(mpi_type, sol, 0, 0, count);
+    set_index_pair_const(mpi_type, out, 0, 0, count);
+    allreduce_and_check(mpi_type, CATEGORY_PAIR, MPI_MINLOC, memtype);
 }
 
 static void test_allred(mtest_mem_type_e evenmem, mtest_mem_type_e oddmem)
@@ -576,59 +594,89 @@ static void test_allred(mtest_mem_type_e evenmem, mtest_mem_type_e oddmem)
     else
         memtype = oddmem;
 
-    test_types_set2_sum_1();
-    test_types_set2_prod_1();
-    test_types_set2_max_1();
-    test_types_set2_min_1();
+    malloc_in_out_sol(memtype, rank);
 
-    test_types_set1_lor_1();
-    test_types_set1_lor_2();
+    int num_int_types = sizeof(int_types) / sizeof(MPI_Datatype);
+    for (int i = 0; i < num_int_types; i++) {
+        MPI_Datatype mpi_type = int_types[i];
+        int category = CATEGORY_INT;
+        sum_test_1(mpi_type, category, memtype);
+        prod_test_1(mpi_type, category, memtype);
+        max_test_1(mpi_type, category, memtype);
+        min_test_1(mpi_type, category, memtype);
+        lor_test_1(mpi_type, category, memtype);
+        lor_test_2(mpi_type, category, memtype);
+        lxor_test_1(mpi_type, category, memtype);
+        lxor_test_2(mpi_type, category, memtype);
+        lxor_test_3(mpi_type, category, memtype);
+        land_test_1(mpi_type, category, memtype);
+        land_test_2(mpi_type, category, memtype);
+        bor_test_1(mpi_type, category, memtype);
+        band_test_1(mpi_type, category, memtype);
+        band_test_2(mpi_type, category, memtype);
+        bxor_test_1(mpi_type, category, memtype);
+        bxor_test_2(mpi_type, category, memtype);
+        bxor_test_3(mpi_type, category, memtype);
+    }
 
-    test_types_set1_lxor_1();
-    test_types_set1_lxor_2();
-    test_types_set1_lxor_3();
+    int num_float_types = sizeof(float_types) / sizeof(MPI_Datatype);
+    for (int i = 0; i < num_float_types; i++) {
+        MPI_Datatype mpi_type = float_types[i];
+        int category = CATEGORY_FLOAT;
+        sum_test_1(mpi_type, category, memtype);
+        prod_test_1(mpi_type, category, memtype);
+        max_test_1(mpi_type, category, memtype);
+        min_test_1(mpi_type, category, memtype);
+    }
 
-    test_types_set1_land_1();
-    test_types_set1_land_2();
+    int num_byte_types = sizeof(byte_types) / sizeof(MPI_Datatype);
+    for (int i = 0; i < num_byte_types; i++) {
+        MPI_Datatype mpi_type = byte_types[i];
+        int category = CATEGORY_INT;
+        bor_test_1(mpi_type, category, memtype);
+        band_test_1(mpi_type, category, memtype);
+        band_test_2(mpi_type, category, memtype);
+        bxor_test_1(mpi_type, category, memtype);
+        bxor_test_2(mpi_type, category, memtype);
+        bxor_test_3(mpi_type, category, memtype);
+    }
 
-    test_types_set1_bor_1();
-    test_types_set1_band_1();
-    test_types_set1_band_2();
+#if MTEST_HAVE_MIN_MPI_VERSION(2,2)
+    int num_complex_types = sizeof(complex_types) / sizeof(MPI_Datatype);
+    for (int i = 0; i < num_byte_types; i++) {
+        MPI_Datatype mpi_type = complex_types[i];
+        int category = CATEGORY_COMPLEX;
+        if (mpi_type != MPI_DATATYPE_NULL) {
+            sum_test_1(mpi_type, category, memtype);
+            prod_test_1(mpi_type, category, memtype);
+        }
+    }
+#endif
 
-    test_types_set1_bxor_1();
-    test_types_set1_bxor_2();
-    test_types_set1_bxor_3();
+#if MTEST_HAVE_MIN_MPI_VERSION(2,2) && defined(HAVE__BOOL)
+    int num_logical_types = sizeof(logical_types) / sizeof(MPI_Datatype);
+    for (int i = 0; i < num_byte_types; i++) {
+        MPI_Datatype mpi_type = logical_types[i];
+        int category = CATEGORY_INT;
+        if (mpi_type != MPI_DATATYPE_NULL) {
+            lor_test_1(mpi_type, category, memtype);
+            lor_test_2(mpi_type, category, memtype);
+            lxor_test_1(mpi_type, category, memtype);
+            lxor_test_2(mpi_type, category, memtype);
+            lxor_test_3(mpi_type, category, memtype);
+            land_test_1(mpi_type, category, memtype);
+            land_test_2(mpi_type, category, memtype);
+        }
+    }
+#endif
 
-    test_types_set3_bor_1();
-    test_types_set3_band_1();
-    test_types_set3_band_2();
+    int num_pair_types = sizeof(pair_types) / sizeof(MPI_Datatype);
+    for (int i = 0; i < num_pair_types; i++) {
+        maxloc_test(pair_types[i], memtype);
+        minloc_test(pair_types[i], memtype);
+    }
 
-    test_types_set3_bxor_1();
-    test_types_set3_bxor_2();
-    test_types_set3_bxor_3();
-
-    test_types_set4_sum_1();
-    test_types_set4_prod_1();
-
-    test_types_set5_lor_1();
-    test_types_set5_lor_2();
-    test_types_set5_lxor_1();
-    test_types_set5_lxor_2();
-    test_types_set5_lxor_3();
-    test_types_set5_land_1();
-    test_types_set5_land_2();
-
-    maxloc_test_MPI_2INT();
-    maxloc_test_MPI_LONG_INT();
-    maxloc_test_MPI_SHORT_INT();
-    maxloc_test_MPI_FLOAT_INT();
-    maxloc_test_MPI_DOUBLE_INT();
-
-    minloc_test_MPI_2INT();
-    minloc_test_MPI_LONG_INT();
-    minloc_test_MPI_SHORT_INT();
-    minloc_test_MPI_FLOAT_INT();
-    minloc_test_MPI_DOUBLE_INT();
+    free_in_out_sol(memtype);
 
     MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_ARE_FATAL);
 }

--- a/test/mpi/coll/gen_allred.def
+++ b/test/mpi/coll/gen_allred.def
@@ -1,0 +1,410 @@
+page: gen_allred
+    module: perl
+
+    my @out
+    gen_header(\@out)
+
+    $foreach $type in @type_set_all
+        gen_fn_allred_type(\@out, $type)
+
+    my $num_ops = @op_list
+    $for $i=0:$num_ops
+        gen_fn_test_op(\@out, $op_list[$i], $op_num_tests[$i])
+    gen_main(\@out)
+
+    &call open_W, t_allred.c
+        $foreach $l in @out
+            $print $l
+
+subcode: _autoload
+    $global @op_list = ($(op_list:quotelist))
+    $global @op_num_tests = qw(1 1 1 1 2 3 2 1 3 2 1 1)
+    $(for:1-6)
+        $global @type_set$1 = ($(type_set$1:quotelist))
+    $global @type_set_all = (@type_set1, @type_set2, @type_set3, @type_set4, @type_set5, @type_set6)
+
+macros_test:
+    op_list: sum
+    type_set1: INT
+    type_set2:
+    type_set3:
+    type_set4:
+    type_set5:
+    type_set6:
+
+macros:
+    op_list: sum, prod, max, min, lor, lxor, land, bor, bxor, band, maxloc, minloc
+    type_set1:: INT, LONG, SHORT, UNSIGNED_SHORT, UNSIGNED, UNSIGNED_LONG, UNSIGNED_CHAR
+    type_set1:: INT8_T, INT16_T, INT32_T, INT64_T, UINT8_T, UINT16_T, UINT32_T, UINT64_T, MPI_AINT, MPI_OFFSET
+    type_set1:: MPI_COUNT
+    type_set2: FLOAT, DOUBLE
+    type_set3: BYTE
+    type_set4: C_FLOAT_COMPLEX, C_DOUBLE_COMPLEX, C_LONG_DOUBLE_COMPLEX
+    type_set5: C_BOOL
+    type_set6: 2INT, LONG_INT, SHORT_INT, FLOAT_INT, DOUBLE_INT
+
+fncode: get_c_type($T)
+    $if $T=~/(MPI_\w)(\w+)/
+        return $1.lc($2)
+    $elif $T=~/UNSIGNED_(\w+)/
+        return "unsigned ".lc($1)
+    $elif $T=~/C_(\w+)_COMPLEX/
+        my $t = lc($1)
+        $t=~s/_/ /g
+        return "$t _Complex"
+    $elif $T eq "C_BOOL"
+        return "_Bool"
+    $elif $T eq "BYTE"
+        return "unsigned char"
+    $elif $T eq "2INT"
+        return "struct int_test"
+    $elif $T eq "LONG_INT"
+        return "struct long_test"
+    $elif $T eq "SHORT_INT"
+        return "struct short_test"
+    $elif $T eq "FLOAT_INT"
+        return "struct float_test"
+    $elif $T eq "DOUBLE_INT"
+        return "struct double_test"
+    $else
+        return lc($T)
+
+fncode: get_mpi_type($T)
+    $if $T=~/^MPI_/
+        return $T
+    $else
+        return "MPI_$T"
+
+fncode: get_mpi_op($op)
+    return "MPI_".uc($op)
+
+#----------------------------------------
+fncode: gen_fn_test_op($out, $op, $n)
+    my @type_list
+    $if $op =~ /^(sum|prod)/
+        push @type_list, @type_set1, @type_set2, @type_set4
+    $elif $op =~ /^(max|min)$/
+        push @type_list, @type_set1, @type_set2
+    $elif $op =~ /^(max|min)loc$/
+        push @type_list, @type_set6
+    $elif $op =~ /^l(or|xor|and)$/
+        push @type_list, @type_set1, @type_set5
+    $elif $op =~ /^b(or|xor|and)$/
+        push @type_list, @type_set1, @type_set3
+
+    $for $type in @type_list
+        $for $i=0:$n
+            gen_fn_type_op_type($out, $op, $type, $i+1)
+
+    push @$out, "static void test_$op()"
+    push @$out, "{"
+    $for $type in @type_list
+        $for $i=0:$n
+            my $fn_name = "test_".$op."_$type"."_".($i+1)
+            push @$out, "    $fn_name();"
+    push @$out, "}"
+
+fncode: gen_fn_type_op_type($out, $op, $type, $idx)
+    my $c_type = get_c_type($type)
+    my $mpi_type = get_mpi_type($type)
+    my $mpi_op = get_mpi_op($op)
+    my $fn_name = "test_".$op."_$type"."_$idx"
+
+    push @$out, "static void $fn_name()"
+    push @$out, "{"
+    push @$out, "    $c_type *in, *out, *sol;"
+    push @$out, "    in = ($c_type *) calloc(count, sizeof($c_type));"
+    push @$out, "    out = ($c_type *) calloc(count, sizeof($c_type));"
+    push @$out, "    sol = ($c_type *) calloc(count, sizeof($c_type));"
+
+    setup_in_sol_out($out, $op, $idx)
+
+    push @$out, "    allred_check_$type(in, out, sol, $mpi_op);"
+    push @$out, "    free(in); free(out); free(sol);"
+
+    push @$out, "}"
+
+fncode: setup_in_sol_out($out, $op, $idx)
+    $(for:op in sum,prod,max,min,lor,lxor,land,bor,bxor,band,maxloc,minloc)
+        $case $op eq "$(op)"
+            $(for:i in 1-3)
+                $(if:hascode:set_$(op)_$(i))
+                    $if $idx == $(i)
+                        $call set_$(op)_$(i)
+
+    subcode: set_sum_1
+        set_index_sum($out, "in", "0");
+        set_index_factor($out, "sol", "size");
+        set_index_const($out, "out", "0");
+    subcode: set_prod_1
+        set_index_sum($out, "in", "0");
+        set_index_power($out, "sol", "size");
+        set_index_const($out, "out", "0");
+    subcode: set_max_1
+        set_index_sum($out, "in", "rank");
+        set_index_sum($out, "sol", "size - 1");
+        set_index_const($out, "out", "0");
+    subcode: set_min_1
+        set_index_sum($out, "in", "rank");
+        set_index_sum($out, "sol", "0");
+        set_index_const($out, "out", "0");
+    subcode: set_const(a, b, c)
+        set_index_const($out, "in", $(a));
+        set_index_const($out, "sol", $(b));
+        set_index_const($out, "out", $(c));
+
+    subcode: set_lor_1
+        $call set_const, "(rank & 0x1)", "(size > 1)", "0"
+
+    subcode: set_lor_2
+        $call set_const, "0", "0", "0"
+
+    subcode: set_lxor_1
+        $call set_const, "(rank == 1)", "(size > 1)", "0"
+
+    subcode: set_lxor_2
+        $call set_const, "0", "0", "0"
+
+    subcode: set_lxor_3
+        $call set_const, "1", "(size & 0x1)", "0"
+
+    subcode: set_land_1
+        $call set_const, "(rank & 0x1)", "0", "0"
+
+    subcode: set_land_2
+        $call set_const, "1", "1", "0"
+
+    subcode: set_bor_1
+        $call set_const, "(rank & 0x3)", "((size < 3) ? size - 1 : 0x3)", "0"
+
+    subcode: set_bxor_1
+        $call set_const, "(rank == 1) * 0xf0", "(size > 1) * 0xf0", "0"
+
+    subcode: set_bxor_2
+        $call set_const, "0", "0", "0"
+
+    subcode: set_bxor_3
+        $call set_const, "~0", "((size & 0x1) ? ~0 : 0)", "0"
+
+    subcode: set_band_1
+        push @$out, "    if (rank == size - 1) {"
+        set_index_sum($out, "in", "0")
+        push @$out, "    } else {"
+        set_index_const($out, "in", "~0")
+        push @$out, "    }"
+        set_index_sum($out, "sol", "0");
+        set_index_const($out, "out", "0");
+
+    subcode: set_band_2
+        push @$out, "    if (rank == size - 1) {"
+        set_index_sum($out, "in", "0")
+        push @$out, "    } else {"
+        set_index_const($out, "in", "0")
+        push @$out, "    }"
+        set_index_const($out, "sol", "0");
+        set_index_const($out, "out", "0");
+
+    subcode: set_maxloc_1
+        set_index_pair($out, "in", "sum", "rank", "const", "rank")
+        set_index_pair($out, "sol", "sum", "size - 1", "const", "size - 1")
+        set_index_pair($out, "out", "const", "0", "const", "-1")
+
+    subcode: set_minloc_1
+        set_index_pair($out, "in", "sum", "rank", "const", "rank")
+        set_index_pair($out, "sol", "sum", "0", "const", "0")
+        set_index_pair($out, "out", "const", "0", "const", "-1")
+
+#----------------------------------------
+fncode: set_index_const($out, $arr, $val)
+    push @$out, "    for (int i = 0; i < count; i++) {"
+    push @$out, "        $arr\[i] = $val;"
+    push @$out, "    }"
+
+fncode: set_index_sum($out, $arr, $val)
+    push @$out, "    for (int i = 0; i < count; i++) {"
+    push @$out, "        $arr\[i] = i + $val;"
+    push @$out, "    }"
+
+fncode: set_index_factor($out, $arr, $val)
+    push @$out, "    for (int i = 0; i < count; i++) {"
+    push @$out, "        $arr\[i] = i * $val;"
+    push @$out, "    }"
+
+fncode: set_index_power($out, $arr, $val)
+    push @$out, "    for (int i = 0; i < count; i++) {"
+    push @$out, "        $arr\[i] = 1;"
+    push @$out, "        for (int j = 0; j < $val; j++) {"
+    push @$out, "            $arr\[i] *= i;"
+    push @$out, "        }"
+    push @$out, "    }"
+
+fncode: set_index_pair($out, $arr, $set_a, $val_a, $set_b, $val_b)
+    push @$out, "    for (int i = 0; i < count; i++) {"
+    $(for:a, b)
+        $if $set_$1 eq "const"
+            push @$out, "        $arr\[i].$1 = $val_$1;"
+        $elif $set_$1 eq "sum"
+            push @$out, "        $arr\[i].$1 = i + $val_$1;"
+    push @$out, "    }"
+
+#----------------------------------------
+fncode: gen_header($out)
+    &call here_doc, HEADER
+        $call gen_header_template
+
+template: gen_header_template
+    \x2f*
+    \x20* Copyright (C) by Argonne National Laboratory
+    \x20*     See COPYRIGHT in top-level directory
+    \x20*/
+
+    \x2f*      Warning - this test will fail for MPI_PROD & maybe MPI_SUM
+    \x20*        if more than 10 MPI processes are used.  Loss of precision
+    \x20*        will occur as the number of processors is increased.
+    \x20*/
+
+    #include "mpi.h"
+    #include "mpitest.h"
+    #include <stdio.h>
+    #include <stdlib.h>
+    #include <string.h>
+    #ifdef HAVE_STDINT_H
+    #include <stdint.h>
+    #endif
+
+    int count, size, rank;
+    int errs;
+
+    struct int_test {
+        int a;
+        int b;
+    };
+    struct long_test {
+        long a;
+        int b;
+    };
+    struct short_test {
+        short a;
+        int b;
+    };
+    struct float_test {
+        float a;
+        int b;
+    };
+    struct double_test {
+        double a;
+        int b;
+    };
+
+    const char *mpi_op2str(MPI_Op op)
+    {
+        return ((op == MPI_SUM) ? "MPI_SUM" :
+            (op == MPI_PROD) ? "MPI_PROD" :
+            (op == MPI_MAX) ? "MPI_MAX" :
+            (op == MPI_MIN) ? "MPI_MIN" :
+            (op == MPI_LOR) ? "MPI_LOR" :
+            (op == MPI_LXOR) ? "MPI_LXOR" :
+            (op == MPI_LAND) ? "MPI_LAND" :
+            (op == MPI_BOR) ? "MPI_BOR" :
+            (op == MPI_BAND) ? "MPI_BAND" :
+            (op == MPI_BXOR) ? "MPI_BXOR" :
+            (op == MPI_MAXLOC) ? "MPI_MAXLOC" :
+            (op == MPI_MINLOC) ? "MPI_MINLOC" :
+            "MPI_NO_OP");
+    }
+
+#----------------------------------------
+fncode: gen_fn_allred_type($out, $type)
+    my $c_type = get_c_type($type)
+    my $mpi_type = get_mpi_type($type)
+
+    my $cond
+    $if $c_type =~ /^struct/
+        $cond = "out[i].a != sol[i].a || out[i].b != sol[i].b"
+    $else
+        $cond = "out[i] != sol[i]"
+
+    &call here_doc, ALLRED
+        $call allred_template
+
+template: allred_template
+    static void allred_check_$type(void *t_in, void *t_out, void *t_sol, MPI_Op op)
+    {
+        $c_type *in = t_in;
+        $c_type *out = t_out;
+        $c_type *sol = t_sol;
+        int lerrcnt = 0;
+
+        int rc = MPI_Allreduce(in, out, count, $mpi_type, op, MPI_COMM_WORLD);
+        if (rc) { lerrcnt++; errs++; MTestPrintError(rc); }
+        else {
+            for (int i = 0; i < count; i++) {
+                if ($cond) {
+                    lerrcnt++;
+                    errs++;
+                }
+            }
+        }
+
+        if (lerrcnt) {
+            char name[MPI_MAX_OBJECT_NAME] = {0};
+            int len = 0;
+            MPI_Type_get_name($mpi_type, name, &len);
+            fprintf(stderr, "(%d) Error for type %s and op %s\\n", rank, name, mpi_op2str(op));
+        }
+    }
+
+#---------------------------------------
+fncode: gen_main($out)
+    &call here_doc, MAIN_A
+        $call gen_main_template_a
+
+    $foreach $op in @op_list
+        push @$out, "    test_$op();"
+
+    &call here_doc, MAIN_B
+        $call gen_main_template_b
+
+template: gen_main_template_a
+    int main(int argc, char **argv)
+    {
+        MTest_Init(&argc, &argv);
+
+        MPI_Comm_size(MPI_COMM_WORLD, &size);
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+        if (size < 2) {
+            fprintf(stderr, "At least 2 processes required\\n");
+            MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+
+        \x2f* Set errors return so that we can provide better information
+        \x20* should a routine reject one of the operand/datatype pairs */
+        MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+        count = 10;
+        \x2f* Allow an argument to override the count.
+        \x20* Note that the product tests may fail if the count is very large.
+        \x20*/
+        if (argc >= 2) {
+            count = atoi(argv[1]);
+            if (count <= 0) {
+                fprintf(stderr, "Invalid count argument %s\\n", argv[1]);
+                MPI_Abort(MPI_COMM_WORLD, 1);
+            }
+        }
+
+template: gen_main_template_b
+    NOOP
+        MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_ARE_FATAL);
+        MTest_Finalize(errs);
+        return MTestReturnValue(errs);
+    }
+
+#----------------------------------------
+subcode: here_doc(name)
+    push @$out, <<"END $(name)"
+    $:: PUSHDENT
+    BLOCK
+    $:: END $(name)
+    $:: POPDENT


### PR DESCRIPTION
## Pull Request Description

Before -
```
$ touch allred.c && time make allred
CC allred.o
allred.c: In function ‘test_allred’:
allred.c:382:12: note: variable tracking size limit exceeded with -fvar-tracking-assignments, retrying without
 static int test_allred(int count, mtest_mem_type_e evenmem, mtest_mem_type_e oddmem)
            ^~~~~~~~~~~
LTLD allred

real    0m24.467s
user    0m24.126s
sys     0m0.355s
```
After -
```
$ touch allred.c && time make allred
CC allred.o
LTLD allred

real    0m4.326s
user    0m4.201s
sys     0m0.138s
```