### PR TITLE
Debug progress TIMEOUTs

### DIFF
--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -8,6 +8,7 @@
 
 #include "mpir_process.h"
 
+#define MPICH_DEBUG_REQUEST 1
 /*
 === BEGIN_MPI_T_CVAR_INFO_BLOCK ===
 
@@ -232,6 +233,10 @@ struct MPIR_Request {
 
     struct MPIR_Request *next, *prev;
 
+#ifdef MPICH_DEBUG_REQUEST
+    char info[100];
+#endif
+
     /* Other, device-specific information */
 #ifdef MPID_DEV_REQUEST_DECL
      MPID_DEV_REQUEST_DECL
@@ -299,6 +304,24 @@ extern MPIR_Request MPIR_Request_direct[MPIR_REQUEST_PREALLOC];
             break; \
         } \
     } while (0)
+
+#ifdef MPICH_DEBUG_REQUEST
+#define MPIR_REQUEST_SET_INFO(req, ...) \
+    do { \
+        MPL_snprintf((req)->info, 100, __VA_ARGS__); \
+    } while (0)
+
+#define MPIR_REQUEST_DEBUG(req) \
+    do { \
+        if (MPIR_cc_get((req)->cc) > 0) { \
+            printf("    %x: %s\n", (req)->handle, (req)->info); \
+        } \
+    } while (0)
+#else
+
+#define MPIR_REQUEST_SET_INFO(req, info) do { } while (0)
+#define MPIR_REQUEST_DEBUG(req) do { } while (0)
+#endif
 
 void MPII_init_request(void);
 
@@ -408,6 +431,9 @@ static inline MPIR_Request *MPIR_Request_create_from_pool(MPIR_Request_kind_t ki
     req->kind = kind;
     MPIR_cc_set(&req->cc, 1);
     req->cc_ptr = &req->cc;
+#ifdef MPICH_DEBUG_REQUEST
+        req->info[0] = '\0';
+#endif
 
     req->status.MPI_ERROR = MPI_SUCCESS;
     MPIR_STATUS_SET_CANCEL_BIT(req->status, FALSE);
@@ -552,6 +578,9 @@ static inline void MPIR_Request_free_with_safety(MPIR_Request * req, int need_sa
         }
 
         MPID_Request_destroy_hook(req);
+#ifdef MPICH_DEBUG_REQUEST
+        MPIR_cc_set(&req->cc, 0);
+#endif
 
         if (need_safety) {
             MPID_THREAD_CS_ENTER(POBJ, MPIR_THREAD_POBJ_HANDLE_MUTEX);
@@ -732,5 +761,7 @@ int MPIR_Waitany(int count, MPI_Request array_of_requests[], MPIR_Request * requ
 int MPIR_Waitsome(int incount, MPI_Request array_of_requests[], MPIR_Request * request_ptrs[],
                   int *outcount, int array_of_indices[], MPI_Status array_of_statuses[]);
 int MPIR_Parrived(MPIR_Request * request_ptr, int partition, int *flag);
+
+void MPIR_Request_debug(void);
 
 #endif /* MPIR_REQUEST_H_INCLUDED */

--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -477,3 +477,25 @@ int MPIR_Grequest_free(MPIR_Request * request_ptr)
 
     return mpi_errno;
 }
+
+void MPIR_Request_debug(void)
+{
+    for (int i = 0; i < MPIR_REQUEST_NUM_POOLS; i++) {
+        int n_pending = MPIR_Request_mem[i].num_allocated - MPIR_Request_mem[i].num_avail;
+        if (n_pending > 0) {
+            printf("%d pending requests in pool %d\n", n_pending, i);
+            if (i == 0) {
+                MPIR_Request *pool = MPIR_Request_direct;
+                for (int j = 0; j < MPIR_Request_mem[0].direct_size; j++) {
+                    MPIR_REQUEST_DEBUG(&pool[j]);
+                }
+            }
+            for (int k = 0; k < MPIR_Request_mem[i].indirect_size; k++) {
+                MPIR_Request *pool = MPIR_Request_mem[i].indirect[k];
+                for (int j = 0; j < REQUEST_NUM_INDICES; j++) {
+                    MPIR_REQUEST_DEBUG(&pool[j]);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Pull Request Description

```
~/work/pull_requests/debug_requests/test/mpi/pt2pt$ MPIR_CVAR_CH4_DEBUG_PROGRESS_TIMEOUT=1 mpirun -n 3 ./test_deadlock
1 pending requests in pool 0
    ac000000:
1 pending requests in pool 0
    ac000001:
1 pending requests in pool 0
    ac000000:
^C[mpiexec@Tiger] Sending Ctrl-C to processes as requested
```

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
