### PR TITLE
dtpools: add DTP_create_obj_custom and DTP_obj_create_idx

### DIFF
--- a/test/mpi/attr/fkeyvaltype.c
+++ b/test/mpi/attr/fkeyvaltype.c
@@ -97,28 +97,22 @@ int main(int argc, char *argv[])
 
         if (attrval != 1) {
             errs++;
-            char *desc;
-            DTP_obj_get_description(obj, &desc);
-            printf("attrval is %d, should be 1, before dup in type %s\n", attrval, desc);
-            free(desc);
+            printf("attrval is %d, should be 1, before dup in type %s\n", attrval,
+                   DTP_obj_get_description(obj));
         }
         MPI_Type_dup(type, &duptype);
         /* Check that the attribute was copied */
         if (attrval != 2) {
             errs++;
-            char *desc;
-            DTP_obj_get_description(obj, &desc);
-            printf("Attribute not incremented when type dup'ed (%s)\n", desc);
-            free(desc);
+            printf("Attribute not incremented when type dup'ed (%s)\n",
+                   DTP_obj_get_description(obj));
             MPI_Abort(MPI_COMM_WORLD, 1);
         }
         MPI_Type_free(&duptype);
         if (attrval != 1) {
             errs++;
-            char *desc;
-            DTP_obj_get_description(obj, &desc);
-            printf("Attribute not decremented when duptype %s freed\n", desc);
-            free(desc);
+            printf("Attribute not decremented when duptype %s freed\n",
+                   DTP_obj_get_description(obj));
             MPI_Abort(MPI_COMM_WORLD, 1);
         }
         /* Check that the attribute was freed in the duptype */
@@ -127,10 +121,8 @@ int main(int argc, char *argv[])
             DTP_obj_free(obj);
             if (attrval != 0) {
                 errs++;
-                char *desc;
-                DTP_obj_get_description(obj, &desc);
-                fprintf(stderr, "Attribute not decremented when type %s freed\n", desc);
-                free(desc);
+                fprintf(stderr, "Attribute not decremented when type %s freed\n",
+                        DTP_obj_get_description(obj));
                 MPI_Abort(MPI_COMM_WORLD, 1);
             }
         } else {

--- a/test/mpi/cxx/attr/fkeyvaltypex.cxx
+++ b/test/mpi/cxx/attr/fkeyvaltypex.cxx
@@ -109,28 +109,18 @@ int main(int argc, char *argv[])
 
         if (attrval != 1) {
             errs++;
-            char *desc;
-            DTP_obj_get_description(obj, &desc);
-            cerr << "attrval is " << attrval << ", should be 1, before dup in type " << desc
-                << "\n";
-            free(desc);
+            cerr << "attrval is " << attrval << ", should be 1, before dup in type " << DTP_obj_get_description(obj) << "\n";
         }
         duptype = type.Dup();
         /* Check that the attribute was copied */
         if (attrval != 2) {
             errs++;
-            char *desc;
-            DTP_obj_get_description(obj, &desc);
-            cerr << "Attribute not incremented when type dup'ed (" << desc << ")\n";
-            free(desc);
+            cerr << "Attribute not incremented when type dup'ed (" << DTP_obj_get_description(obj) << ")\n";
         }
         duptype.Free();
         if (attrval != 1) {
             errs++;
-            char *desc;
-            DTP_obj_get_description(obj, &desc);
-            cerr << "Attribute not decremented when duptype " << desc << " freed\n";
-            free(desc);
+            cerr << "Attribute not decremented when duptype " << DTP_obj_get_description(obj) << " freed\n";
         }
         /* Check that the attribute was freed in the duptype */
 
@@ -138,10 +128,7 @@ int main(int argc, char *argv[])
             DTP_obj_free(obj);
             if (attrval != 0) {
                 errs++;
-                char *desc;
-                DTP_obj_get_description(obj, &desc);
-                cerr << "Attribute not decremented when type " << desc << "reed\n";
-                free(desc);
+                cerr << "Attribute not decremented when type " << DTP_obj_get_description(obj) << "reed\n";
             }
         } else {
             MPI_Type_delete_attr(type, saveKeyval);

--- a/test/mpi/cxx/datatype/packsizex.cxx
+++ b/test/mpi/cxx/datatype/packsizex.cxx
@@ -75,18 +75,12 @@ int main(int argc, char *argv[])
         size2 = type.Pack_size(2, comm);
         if (size1 <= 0 || size2 <= 0) {
             errs++;
-            char *desc;
-            DTP_obj_get_description(msobj, &desc);
-            cerr << "Pack size of datatype " << desc << " is not positive\n";
-            free(desc);
+            cerr << "Pack size of datatype " << DTP_obj_get_description(obj) << " is not positive\n";
         }
         if (size1 >= size2) {
             errs++;
-            char *desc;
-            DTP_obj_get_description(msobj, &desc);
-            cerr << "Pack size of 2 of " << desc <<
+            cerr << "Pack size of 2 of " << DTP_obj_get_description(obj) <<
                 " is smaller or the same as the pack size of 1 instance\n";
-            free(desc);
         }
 
         if (mrobj.DTP_datatype != msobj.DTP_datatype) {
@@ -99,18 +93,12 @@ int main(int argc, char *argv[])
             size2 = type.Pack_size(2, comm);
             if (size1 <= 0 || size2 <= 0) {
                 errs++;
-                char *desc;
-                DTP_obj_get_description(mrobj, &desc);
-                cerr << "Pack size of datatype " << desc << " is not positive\n";
-                free(desc);
+                cerr << "Pack size of datatype " << DTP_obj_get_description(obj) << " is not positive\n";
             }
             if (size1 >= size2) {
                 errs++;
-                char *desc;
-                DTP_obj_get_description(mrobj, &desc);
-                cerr << "Pack size of 2 of " << desc <<
+                cerr << "Pack size of 2 of " << DTP_obj_get_description(obj) <<
                     " is smaller or the same as the pack size of 1 instance\n";
-                free(desc);
             }
         }
         DTP_obj_free(mrobj);

--- a/test/mpi/dtpools/include/dtpools.h
+++ b/test/mpi/dtpools/include/dtpools.h
@@ -36,6 +36,9 @@ int DTP_pool_create(const char *basic_type_str, MPI_Aint basic_type_count, int s
 int DTP_pool_free(DTP_pool_s dtp);
 
 int DTP_obj_create(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize);
+int DTP_obj_create_idx(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize, int rand_idx);
+int DTP_obj_create_custom(DTP_pool_s dtp, DTP_obj_s * obj, const char *desc);
+
 int DTP_obj_free(DTP_obj_s obj);
 int DTP_obj_get_description(DTP_obj_s obj, char **desc);
 

--- a/test/mpi/dtpools/include/dtpools.h
+++ b/test/mpi/dtpools/include/dtpools.h
@@ -40,7 +40,7 @@ int DTP_obj_create_idx(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize, int
 int DTP_obj_create_custom(DTP_pool_s dtp, DTP_obj_s * obj, const char *desc);
 
 int DTP_obj_free(DTP_obj_s obj);
-int DTP_obj_get_description(DTP_obj_s obj, char **desc);
+const char *DTP_obj_get_description(DTP_obj_s obj);
 
 int DTP_obj_buf_init(DTP_obj_s obj, void *buf, int val_start, int val_stride, MPI_Aint val_count);
 int DTP_obj_buf_check(DTP_obj_s obj, void *buf, int val_start, int val_stride, MPI_Aint val_count);

--- a/test/mpi/dtpools/include/dtpools_internal.h
+++ b/test/mpi/dtpools/include/dtpools_internal.h
@@ -435,6 +435,7 @@ typedef struct DTPI_Attr {
 typedef struct {
     DTP_pool_s dtp;
     DTPI_Attr_s *attr_tree;
+    const char *desc;
 } DTPI_obj_s;
 
 int DTPI_obj_free(DTPI_obj_s * obj_priv);

--- a/test/mpi/dtpools/include/dtpools_internal.h
+++ b/test/mpi/dtpools/include/dtpools_internal.h
@@ -439,11 +439,15 @@ typedef struct {
 
 int DTPI_obj_free(DTPI_obj_s * obj_priv);
 int DTPI_parse_base_type_str(DTP_pool_s * dtp, const char *str);
+int DTPI_parse_desc(const char *desc, const char **desc_list, int *depth, int max_depth);
 unsigned int DTPI_low_count(unsigned int count);
 unsigned int DTPI_high_count(unsigned int count);
 int DTPI_construct_datatype(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s ** attr_tree,
                             MPI_Datatype * newtype, MPI_Aint * new_count);
+int DTPI_custom_datatype(DTP_pool_s dtp, DTPI_Attr_s ** attr_tree, MPI_Datatype * newtype,
+                         MPI_Aint * new_count, const char **desc_list, int depth);
 int DTPI_populate_dtp_desc(DTPI_obj_s * obj_priv, DTPI_pool_s * dtpi, char **desc);
+void DTPI_rand_init(DTPI_pool_s * dtpi, int seed, int rand_count);
 int DTPI_rand(DTPI_pool_s * dtpi);
 int DTPI_init_verify(DTP_pool_s dtp, DTP_obj_s obj, void *buf, DTPI_Attr_s * attr_tree,
                      size_t buf_offset, int *val_start, int val_stride, int *rem_val_count,

--- a/test/mpi/dtpools/src/Makefile.am
+++ b/test/mpi/dtpools/src/Makefile.am
@@ -7,5 +7,5 @@ AM_CPPFLAGS = $(MPI_H_INCLUDE)
 AM_CPPFLAGS += -DDTP_MPI_DATATYPE=@DTP_DATATYPES@   # Coma separated list of MPI datatypes
 
 noinst_LTLIBRARIES = libdtpools.la
-libdtpools_la_SOURCES = dtpools.c dtpools_misc.c dtpools_init_verify.c dtpools_desc.c dtpools_attr.c
+libdtpools_la_SOURCES = dtpools.c dtpools_misc.c dtpools_init_verify.c dtpools_desc.c dtpools_attr.c dtpools_custom.c
 libdtpools_la_CPPFLAGS = -I$(top_srcdir)/include -I../include $(AM_CPPFLAGS)

--- a/test/mpi/dtpools/src/dtpools.c
+++ b/test/mpi/dtpools/src/dtpools.c
@@ -29,9 +29,7 @@ int DTP_pool_create(const char *base_type_str, MPI_Aint base_type_count, int see
     DTPI_ERR_CHK_RC(rc);
 
     /* setup the random number generation parameters */
-    dtpi->seed = seed;
-    dtpi->rand_count = 0;
-    dtpi->rand_idx = DTPI_RAND_LIST_SIZE;
+    DTPI_rand_init(dtpi, seed, 0);
 
     dtpi->base_type_count = base_type_count;
 
@@ -176,6 +174,78 @@ int DTP_obj_create(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize)
                 goto fn_fail;
             }
         }
+    }
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+int DTP_obj_create_idx(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize, int rand_idx)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    DTPI_pool_s *dtpi = dtp.priv;
+    DTPI_ERR_ARG_CHECK(!dtpi, rc);
+
+    dtpi->rand_idx = rand_idx % DTPI_RAND_LIST_SIZE;
+    rc = DTP_obj_create(dtp, obj, maxbufsize);
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+int DTP_obj_create_custom(DTP_pool_s dtp, DTP_obj_s * obj, const char *desc)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    DTPI_pool_s *dtpi = dtp.priv;
+    DTPI_ERR_ARG_CHECK(!dtpi, rc);
+
+    DTPI_ALLOC_OR_FAIL(obj->priv, sizeof(DTPI_obj_s), rc);
+    DTPI_obj_s *obj_priv = obj->priv;
+    obj_priv->dtp = dtp;
+    if (desc == NULL) {
+        obj_priv->attr_tree = NULL;
+        obj->DTP_datatype = dtp.DTP_base_type;
+        obj->DTP_type_count = dtpi->base_type_count;
+    } else {
+        const char *desc_parts[10];
+        int num_parts;
+        rc = DTPI_parse_desc(desc, desc_parts, &num_parts, 10);
+        DTPI_ERR_CHK_RC(rc);
+        rc = DTPI_custom_datatype(dtp, &obj_priv->attr_tree, &obj->DTP_datatype,
+                                  &obj->DTP_type_count, desc_parts, num_parts);
+        DTPI_ERR_CHK_RC(rc);
+        rc = MPI_Type_commit(&obj->DTP_datatype);
+        DTPI_ERR_CHK_MPI_RC(rc);
+    }
+
+    MPI_Aint true_lb;
+    MPI_Aint true_extent;
+    MPI_Aint lb;
+    MPI_Aint extent;
+
+    rc = MPI_Type_get_true_extent(obj->DTP_datatype, &true_lb, &true_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    rc = MPI_Type_get_extent(obj->DTP_datatype, &lb, &extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+
+    obj->DTP_bufsize = (extent * obj->DTP_type_count) + true_extent - extent;
+    if (true_lb > 0) {
+        obj->DTP_bufsize += true_lb;
+        obj->DTP_buf_offset = 0;
+    } else {
+        obj->DTP_buf_offset = -true_lb;
     }
 
   fn_exit:

--- a/test/mpi/dtpools/src/dtpools_custom.c
+++ b/test/mpi/dtpools/src/dtpools_custom.c
@@ -1,0 +1,694 @@
+#include <string.h>
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <ctype.h>
+#include "dtpools_internal.h"
+
+#define SKIP_SPACE while (isspace(*s)) s++
+#define EXPECT_DIGIT \
+    do { \
+        while (isspace(*s)) s++; \
+        if (!isdigit(*s)) { \
+            DTPI_ERR_ASSERT(0, rc); \
+        } \
+    } while (0)
+#define EXPECT_ALPHA \
+    do { \
+        while (isspace(*s)) s++; \
+        if (!isalpha(*s)) { \
+            DTPI_ERR_ASSERT(0, rc); \
+        } \
+    } while (0)
+#define EXPECT_CHAR(c) \
+    do { \
+        while (isspace(*s)) s++; \
+        if (*s != (c)) { \
+            DTPI_ERR_ASSERT(0, rc); \
+        } \
+    } while (0)
+#define SKIP_DIGIT \
+    do { \
+        while (*s && isdigit(*s)) s++; \
+        DTPI_ERR_ASSERT(*s, rc); \
+    } while (0)
+#define SKIP_ALPHA \
+    do { \
+        while (*s && isalpha(*s)) s++; \
+        DTPI_ERR_ASSERT(*s, rc); \
+    } while (0)
+#define SKIP_UNTIL(c) \
+    do { \
+        while (*s && *s != (c)) s++; \
+        DTPI_ERR_ASSERT(*s, rc); \
+    } while (0)
+
+int DTPI_parse_desc(const char *s, const char **parts, int *num_parts, int max_parts)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    int i = 0;
+    while (*s) {
+        EXPECT_DIGIT;
+        SKIP_DIGIT;
+        EXPECT_CHAR(':');
+        s++;
+        EXPECT_ALPHA;
+
+        parts[i++] = s;
+        DTPI_ERR_ASSERT(i < max_parts, rc);
+
+        SKIP_ALPHA;
+        EXPECT_CHAR('[');
+        SKIP_UNTIL(']');
+        s++;
+        SKIP_SPACE;
+    }
+    *num_parts = i;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_contig(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                         MPI_Aint * new_count, const char *desc, MPI_Datatype type, MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__CONTIG;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "blklen %d", &attr->u.contig.blklen);
+    DTPI_ERR_ASSERT(n == 1, rc);
+    rc = MPI_Type_contiguous(attr->u.contig.blklen, type, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    DTPI_ERR_ASSERT(count % attr->u.contig.blklen == 0, rc);
+    count /= attr->u.contig.blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_dup(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                      MPI_Aint * new_count, const char *desc, MPI_Datatype type, MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__DUP;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    rc = MPI_Type_dup(type, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_resized(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                          MPI_Aint * new_count, const char *desc, MPI_Datatype type, MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__RESIZED;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "lb %zd, extent %zd", &attr->u.resized.lb, &attr->u.resized.extent);
+    DTPI_ERR_ASSERT(n == 2, rc);
+    rc = MPI_Type_create_resized(type, attr->u.resized.lb, attr->u.resized.extent, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_vector(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                         MPI_Aint * new_count, const char *desc, MPI_Datatype type, MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__VECTOR;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d, blklen %d, stride %d", &attr->u.vector.numblks,
+               &attr->u.vector.blklen, &attr->u.vector.stride);
+    DTPI_ERR_ASSERT(n == 3, rc);
+    rc = MPI_Type_vector(attr->u.vector.numblks, attr->u.vector.blklen, attr->u.vector.stride, type,
+                         newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    DTPI_ERR_ASSERT(count % (attr->u.vector.numblks * attr->u.vector.blklen) == 0, rc);
+    count /= attr->u.vector.numblks * attr->u.vector.blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_hvector(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                          MPI_Aint * new_count, const char *desc, MPI_Datatype type, MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__HVECTOR;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d, blklen %d, stride %zd", &attr->u.hvector.numblks,
+               &attr->u.hvector.blklen, &attr->u.hvector.stride);
+    DTPI_ERR_ASSERT(n == 3, rc);
+    rc = MPI_Type_hvector(attr->u.hvector.numblks, attr->u.hvector.blklen, attr->u.hvector.stride,
+                          type, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    DTPI_ERR_ASSERT(count % (attr->u.hvector.numblks * attr->u.hvector.blklen) == 0, rc);
+    count /= attr->u.hvector.numblks * attr->u.hvector.blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_blkindx(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                          MPI_Aint * new_count, const char *desc, MPI_Datatype type, MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__BLKINDX;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d, blklen %d", &attr->u.blkindx.numblks, &attr->u.blkindx.blklen);
+    DTPI_ERR_ASSERT(n == 2, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.blkindx.array_of_displs, attr->u.blkindx.numblks * sizeof(int), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.blkindx.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.blkindx.array_of_displs[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+
+    rc = MPI_Type_create_indexed_block(attr->u.blkindx.numblks, attr->u.blkindx.blklen,
+                                       attr->u.blkindx.array_of_displs, type, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    DTPI_ERR_ASSERT(count % (attr->u.blkindx.numblks * attr->u.blkindx.blklen) == 0, rc);
+    count /= attr->u.blkindx.numblks * attr->u.blkindx.blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_blkhindx(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                           MPI_Aint * new_count, const char *desc, MPI_Datatype type,
+                           MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__BLKHINDX;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d, blklen %d", &attr->u.blkhindx.numblks, &attr->u.blkhindx.blklen);
+    DTPI_ERR_ASSERT(n == 2, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.blkhindx.array_of_displs,
+                       attr->u.blkhindx.numblks * sizeof(MPI_Aint), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.blkhindx.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.blkhindx.array_of_displs[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+
+    rc = MPI_Type_create_hindexed_block(attr->u.blkhindx.numblks, attr->u.blkhindx.blklen,
+                                        attr->u.blkhindx.array_of_displs, type, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    DTPI_ERR_ASSERT(count % (attr->u.blkhindx.numblks * attr->u.blkhindx.blklen) == 0, rc);
+    count /= attr->u.blkhindx.numblks * attr->u.blkhindx.blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_indexed(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                          MPI_Aint * new_count, const char *desc, MPI_Datatype type, MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__INDEXED;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d", &attr->u.indexed.numblks);
+    DTPI_ERR_ASSERT(n == 1, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.indexed.array_of_blklens, attr->u.indexed.numblks * sizeof(int), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.indexed.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.indexed.array_of_blklens[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    DTPI_ALLOC_OR_FAIL(attr->u.indexed.array_of_displs, attr->u.indexed.numblks * sizeof(int), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.indexed.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.indexed.array_of_displs[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+
+    rc = MPI_Type_indexed(attr->u.indexed.numblks, attr->u.indexed.array_of_blklens,
+                          attr->u.indexed.array_of_displs, type, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+
+    int total_blklen = 0;
+    for (int i = 0; i < attr->u.indexed.numblks; i++) {
+        total_blklen += attr->u.indexed.array_of_blklens[i];
+    }
+    DTPI_ERR_ASSERT(count % total_blklen == 0, rc);
+    count /= total_blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_hindexed(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                           MPI_Aint * new_count, const char *desc, MPI_Datatype type,
+                           MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__HINDEXED;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d", &attr->u.hindexed.numblks);
+    DTPI_ERR_ASSERT(n == 1, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.hindexed.array_of_blklens, attr->u.hindexed.numblks * sizeof(int),
+                       rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.hindexed.array_of_blklens[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    DTPI_ALLOC_OR_FAIL(attr->u.hindexed.array_of_displs,
+                       attr->u.hindexed.numblks * sizeof(MPI_Aint), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.hindexed.array_of_displs[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+
+    rc = MPI_Type_hindexed(attr->u.hindexed.numblks, attr->u.hindexed.array_of_blklens,
+                           attr->u.hindexed.array_of_displs, type, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+
+    int total_blklen = 0;
+    for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+        total_blklen += attr->u.hindexed.array_of_blklens[i];
+    }
+    DTPI_ERR_ASSERT(count % total_blklen == 0, rc);
+    count /= total_blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_subarray(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                           MPI_Aint * new_count, const char *desc, MPI_Datatype type,
+                           MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__SUBARRAY;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "ndims %d", &attr->u.subarray.ndims);
+    DTPI_ERR_ASSERT(n == 1, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.subarray.array_of_sizes, attr->u.subarray.ndims * sizeof(int), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.subarray.ndims; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.subarray.array_of_sizes[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    DTPI_ALLOC_OR_FAIL(attr->u.subarray.array_of_subsizes, attr->u.subarray.ndims * sizeof(int),
+                       rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.subarray.ndims; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.subarray.array_of_subsizes[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    DTPI_ALLOC_OR_FAIL(attr->u.subarray.array_of_starts, attr->u.subarray.ndims * sizeof(int), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.subarray.ndims; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.subarray.array_of_starts[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    SKIP_UNTIL('o');
+    if (strncmp(s, "order MPI_ORDER_C", 17) == 0) {
+        attr->u.subarray.order = MPI_ORDER_C;
+    } else if (strncmp(s, "order MPI_ORDER_FORTRAN", 23) == 0) {
+        attr->u.subarray.order = MPI_ORDER_FORTRAN;
+    } else {
+        DTPI_ERR_ASSERT(0, rc);
+    }
+
+    rc = MPI_Type_create_subarray(attr->u.subarray.ndims, attr->u.subarray.array_of_sizes,
+                                  attr->u.subarray.array_of_subsizes,
+                                  attr->u.subarray.array_of_starts, attr->u.subarray.order, type,
+                                  newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+
+    int total_blklen = 1;
+    for (int i = 0; i < attr->u.subarray.ndims; i++) {
+        total_blklen *= attr->u.subarray.array_of_sizes[i];
+    }
+    DTPI_ERR_ASSERT(count % total_blklen == 0, rc);
+    count /= total_blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_struct(DTP_pool_s dtp, DTPI_Attr_s * attr, MPI_Datatype * newtype,
+                         MPI_Aint * new_count, const char *desc, MPI_Datatype type, MPI_Aint count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__STRUCT;
+    MPI_Aint tmp_lb;
+    rc = MPI_Type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d", &attr->u.structure.numblks);
+    DTPI_ERR_ASSERT(n == 1, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.structure.array_of_blklens, attr->u.structure.numblks * sizeof(int),
+                       rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.structure.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.structure.array_of_blklens[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    DTPI_ALLOC_OR_FAIL(attr->u.structure.array_of_displs,
+                       attr->u.structure.numblks * sizeof(MPI_Aint), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.structure.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.structure.array_of_displs[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    MPI_Datatype *array_of_types;
+    DTPI_ALLOC_OR_FAIL(array_of_types, attr->u.structure.numblks * sizeof(MPI_Datatype), rc);
+    for (int i = 0; i < attr->u.structure.numblks; i++) {
+        array_of_types[i] = type;
+    }
+    rc = MPI_Type_create_struct(attr->u.structure.numblks, attr->u.structure.array_of_blklens,
+                                attr->u.structure.array_of_displs, array_of_types, newtype);
+    DTPI_ERR_CHK_MPI_RC(rc);
+    DTPI_FREE(array_of_types);
+
+    int total_blklen = 0;
+    for (int i = 0; i < attr->u.structure.numblks; i++) {
+        total_blklen += attr->u.structure.array_of_blklens[i];
+    }
+    DTPI_ERR_ASSERT(count % total_blklen == 0, rc);
+    count /= total_blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+int DTPI_custom_datatype(DTP_pool_s dtp, DTPI_Attr_s ** attr_tree, MPI_Datatype * newtype,
+                         MPI_Aint * new_count, const char **desc_list, int depth)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    if (depth == 0) {
+        DTPI_pool_s *dtpi = dtp.priv;
+        *attr_tree = NULL;
+        *newtype = dtp.DTP_base_type;
+        *new_count = dtpi->base_type_count;
+        goto fn_exit;
+    }
+
+    DTPI_Attr_s *attr;
+    DTPI_ALLOC_OR_FAIL(attr, sizeof(DTPI_Attr_s), rc);
+    *attr_tree = attr;
+
+    MPI_Datatype type;
+    MPI_Aint count;
+    rc = DTPI_custom_datatype(dtp, &attr->child, &type, &count, desc_list + 1, depth - 1);
+    DTPI_ERR_CHK_RC(rc);
+
+    const char *s = desc_list[0];
+    if (strncmp(s, "contig", 6) == 0) {
+        rc = custom_contig(dtp, attr, newtype, new_count, s + 6, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "dup", 3) == 0) {
+        rc = custom_dup(dtp, attr, newtype, new_count, s + 3, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "resized", 7) == 0) {
+        rc = custom_resized(dtp, attr, newtype, new_count, s + 7, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "vector", 6) == 0) {
+        rc = custom_vector(dtp, attr, newtype, new_count, s + 6, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "hvector", 7) == 0) {
+        rc = custom_hvector(dtp, attr, newtype, new_count, s + 7, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "blkindx", 7) == 0) {
+        rc = custom_blkindx(dtp, attr, newtype, new_count, s + 7, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "blkhindx", 8) == 0) {
+        rc = custom_blkhindx(dtp, attr, newtype, new_count, s + 8, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "indexed", 7) == 0) {
+        rc = custom_indexed(dtp, attr, newtype, new_count, s + 7, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "hindexed", 8) == 0) {
+        rc = custom_hindexed(dtp, attr, newtype, new_count, s + 8, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "subarray", 8) == 0) {
+        rc = custom_subarray(dtp, attr, newtype, new_count, s + 8, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "structure", 9) == 0) {
+        rc = custom_struct(dtp, attr, newtype, new_count, s + 9, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "struct", 6) == 0) {
+        rc = custom_struct(dtp, attr, newtype, new_count, s + 6, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else {
+        DTPI_ERR_ASSERT(0, rc);
+    }
+
+    if (depth > 1) {
+        rc = MPI_Type_free(&type);
+        DTPI_ERR_CHK_MPI_RC(rc);
+    }
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}

--- a/test/mpi/dtpools/src/dtpools_misc.c
+++ b/test/mpi/dtpools/src/dtpools_misc.c
@@ -214,6 +214,22 @@ unsigned int DTPI_high_count(unsigned int count)
     return count / DTPI_low_count(count);
 }
 
+void DTPI_rand_init(DTPI_pool_s * dtpi, int seed, int rand_count)
+{
+    dtpi->seed = seed;
+    dtpi->rand_count = rand_count;
+    dtpi->rand_idx = 0;
+
+    srand(dtpi->seed);
+    for (int i = 0; i < dtpi->rand_count; i++)
+        rand();
+
+    for (int i = 0; i < DTPI_RAND_LIST_SIZE; i++) {
+        dtpi->rand_count++;
+        dtpi->rand_list[i] = rand();
+    }
+}
+
 int DTPI_rand(DTPI_pool_s * dtpi)
 {
     int ret;
@@ -225,15 +241,6 @@ int DTPI_rand(DTPI_pool_s * dtpi)
 
     if (dtpi->rand_idx == DTPI_RAND_LIST_SIZE) {
         dtpi->rand_idx = 0;
-
-        srand(dtpi->seed);
-        for (int i = 0; i < dtpi->rand_count; i++)
-            rand();
-
-        for (int i = 0; i < DTPI_RAND_LIST_SIZE; i++) {
-            dtpi->rand_count++;
-            dtpi->rand_list[i] = rand();
-        }
     }
 
     ret = dtpi->rand_list[dtpi->rand_idx];

--- a/test/mpi/include/mtest_dtp.h
+++ b/test/mpi/include/mtest_dtp.h
@@ -392,10 +392,7 @@ static inline int MTest_dtp_destroy(struct mtest_obj *obj)
 /* utilitis for each instance of dtp obj */
 static inline void MTest_dtp_print_desc(struct mtest_obj *obj)
 {
-    char *desc;
-    DTP_obj_get_description(obj->dtp_obj, &desc);
-    printf("%s [%s]\n", obj->name, desc);
-    free(desc);
+    printf("%s [%s]\n", obj->name, DTP_obj_get_description(obj->dtp_obj));
 }
 
 static inline int MTest_dtp_init(struct mtest_obj *obj, int start, int stride, int count)

--- a/test/mpi/part/pingping.c
+++ b/test/mpi/part/pingping.c
@@ -150,12 +150,10 @@ int main(int argc, char *argv[])
                 dtype = send.dtp_obj.DTP_datatype;
                 set_partitions_count(send.dtp_obj.DTP_type_count, &partitions, &partition_count);
 
-                char *desc;
-                DTP_obj_get_description(send.dtp_obj, &desc);
                 MTestPrintfMsg(1,
                                "Sending partitions = %d, count = %ld (total size %d bytes) of datatype %s",
-                               partitions, partition_count, nbytes * sendcnt, desc);
-                free(desc);
+                               partitions, partition_count, nbytes * sendcnt,
+                               DTP_obj_get_description(obj));
 
                 for (nmsg = 1; nmsg < maxmsg; nmsg++)
                     send_test((char *) send.buf + send.dtp_obj.DTP_buf_offset, partitions,
@@ -164,11 +162,8 @@ int main(int argc, char *argv[])
                 dtype = recv.dtp_obj.DTP_datatype;
                 set_partitions_count(recv.dtp_obj.DTP_type_count, &partitions, &partition_count);
 
-                char *desc;
-                DTP_obj_get_description(recv.dtp_obj, &desc);
                 MTestPrintfMsg(1, "Receiving partitions = %d, count = %d of datatype %s\n",
-                               partitions, partition_count, desc);
-                free(desc);
+                               partitions, partition_count, DTP_obj_get_description(obj));
 
                 for (nmsg = 1; nmsg < maxmsg; nmsg++) {
                     MTest_dtp_init(&recv, -1, -1, recvcnt);

--- a/test/mpi/pt2pt/Makefile.am
+++ b/test/mpi/pt2pt/Makefile.am
@@ -67,6 +67,7 @@ noinst_PROGRAMS =  \
     pingping_barrier  \
     sendrecv1 \
     sendself \
+    sendrecv_custom \
     pt2pt_large \
     precv_anysrc \
     precv_anysrc_exp

--- a/test/mpi/pt2pt/sendrecv_custom.c
+++ b/test/mpi/pt2pt/sendrecv_custom.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpitest.h"
+#include "dtpools.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    int ret;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm comm = MPI_COMM_WORLD;
+    int rank, size;
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    int src = 0;
+    int dst = 1;
+    int tag = 0;
+
+    MPI_Aint maxbufsize = MTestDefaultMaxBufferSize();
+
+    int count = 100;
+    int seed = 1;
+    DTP_pool_s dtp;
+    ret = DTP_pool_create("MPI_INT", count, seed, &dtp);
+
+    for (int iter = 0; iter < 3; iter++) {
+        DTP_obj_s send_obj, recv_obj;
+        if (iter == 0) {
+            DTP_obj_create(dtp, &send_obj, maxbufsize);
+            DTP_obj_create(dtp, &recv_obj, maxbufsize);
+        } else if (iter == 1) {
+            if (rank == src) {
+                DTP_obj_create_idx(dtp, &send_obj, maxbufsize, 0);
+            }
+            if (rank == dst) {
+                DTP_obj_create_idx(dtp, &recv_obj, maxbufsize, 1);
+            }
+        } else if (iter == 2) {
+            if (rank == src) {
+                DTP_obj_create_custom(dtp, &send_obj,
+                                      "0: structure [numblks 2, blklen (5,5), displs (8,208)]"
+                                      "1: blkhindx [numblks 2, blklen 1, displs (8,40)]"
+                                      "2: resized [lb 8, extent 8]");
+            }
+            if (rank == dst) {
+                DTP_obj_create_custom(dtp, &recv_obj,
+                                      "0: blkhindx [numblks 2, blklen 1, displs (8,40)]"
+                                      "1: resized [lb 8, extent 8]");
+            }
+        } else {
+            assert(0);
+        }
+
+        if (rank == src) {
+            MTestPrintfMsg(0, "iter=%d, Send obj: count=%ld, %s\n", iter, send_obj.DTP_type_count,
+                           DTP_obj_get_description(send_obj));
+            void *send_buf = malloc(send_obj.DTP_bufsize);
+            DTP_obj_buf_init(send_obj, send_buf, 1, 2, count);
+            ret = MPI_Send((char *) send_buf + send_obj.DTP_buf_offset,
+                           send_obj.DTP_type_count, send_obj.DTP_datatype, dst, tag, comm);
+            free(send_buf);
+        } else if (rank == dst) {
+            MTestPrintfMsg(0, "iter=%d, Recv obj: count=%ld, %s\n", iter, recv_obj.DTP_type_count,
+                           DTP_obj_get_description(recv_obj));
+            void *recv_buf = malloc(recv_obj.DTP_bufsize);
+            ret = MPI_Recv((char *) recv_buf + recv_obj.DTP_buf_offset,
+                           recv_obj.DTP_type_count,
+                           recv_obj.DTP_datatype, src, tag, comm, MPI_STATUS_IGNORE);
+            ret = DTP_obj_buf_check(recv_obj, recv_buf, 1, 2, count);
+            if (ret != DTP_SUCCESS) {
+                errs++;
+                printf("Send datatype: count = %ld, %s\n", send_obj.DTP_type_count,
+                       DTP_obj_get_description(send_obj));
+                printf("Recv datatype: count = %ld, %s\n", recv_obj.DTP_type_count,
+                       DTP_obj_get_description(recv_obj));
+            }
+            free(recv_buf);
+        }
+        if (iter == 0 || rank == src) {
+            DTP_obj_free(send_obj);
+        }
+        if (iter == 0 || rank == dst) {
+            DTP_obj_free(recv_obj);
+        }
+    }
+
+    DTP_pool_free(dtp);
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/rma/fence.c
+++ b/test/mpi/rma/fence.c
@@ -33,10 +33,6 @@ static inline int test(MPI_Comm comm, int rank, int orig_rank, int target_rank,
     targettype = target.dtp_obj.DTP_datatype;
     targetcount = target.dtp_obj.DTP_type_count;
 
-    char *orig_desc, *target_desc;
-    DTP_obj_get_description(orig.dtp_obj, &orig_desc);
-    DTP_obj_get_description(target.dtp_obj, &target_desc);
-
     if (rank == target_rank) {
 #if defined(USE_GET)
         MTest_dtp_init(&target, 0, 1, count);
@@ -104,9 +100,6 @@ static inline int test(MPI_Comm comm, int rank, int orig_rank, int target_rank,
         MPI_Win_fence(0, win);
         MPI_Win_fence(0, win);
     }
-
-    free(orig_desc);
-    free(target_desc);
 
     return errs;
 }


### PR DESCRIPTION
Sometime we would like to create specific datatypes rather than the
random ones for debugging purpose. This patch adds DTP_create_obj_custom
as an alternate method to DTP_create_obj which will create a specific
DTP datatype based a description string.

Each DTP datatype can be reliablly recreated by setting the internal
random index. This PR provides the interface to generate specific
datatype matching the given random index for more specific
reproducibility.

TODO:
* [ ] DTP_SHOW_RAND_IDX=1


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
